### PR TITLE
add lru_cache to secret

### DIFF
--- a/framework/fabricks/utils/secret.py
+++ b/framework/fabricks/utils/secret.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
+from functools import lru_cache
 
 from databricks.sdk.runtime import dbutils, spark
 
@@ -26,6 +27,7 @@ class AccessKey(Secret):
 _scopes = None
 
 
+@lru_cache(maxsize=128)
 def _get_secret_from_secret_scope(secret_scope: str, name: str) -> str:
     global _scopes
     if not _scopes or secret_scope not in _scopes:  # we get the scopes only once, unless you search for something new

--- a/framework/fabricks/utils/secret.py
+++ b/framework/fabricks/utils/secret.py
@@ -27,7 +27,7 @@ class AccessKey(Secret):
 _scopes = None
 
 
-@lru_cache(maxsize=128)
+@lru_cache(maxsize=None)
 def _get_secret_from_secret_scope(secret_scope: str, name: str) -> str:
     global _scopes
     if not _scopes or secret_scope not in _scopes:  # we get the scopes only once, unless you search for something new


### PR DESCRIPTION
Caching the secret will help reduce the number of calls to dbutils. I think we could do more caching throughout the framework. Worst case, if the node does not have the function cached, it has to call it again.