### PR TITLE
Update timestamp casting to use current_timestamp() in SQL templates and job script

### DIFF
--- a/framework/fabricks/cdc/templates/merge/scd1.sql.jinja
+++ b/framework/fabricks/cdc/templates/merge/scd1.sql.jinja
@@ -27,7 +27,7 @@
     __timestamp = s.__timestamp,
 {% endif %}
 {% if has_metadata %}
-    __metadata.updated = cast(current_date() as timestamp),    
+    __metadata.updated = cast(current_timestamp() as timestamp),    
 {% endif %}
 {% if has_hash %}
     __hash = s.__hash,
@@ -48,7 +48,7 @@
     __is_current = False,
     __is_deleted = True,
     {% if has_metadata %}
-    __metadata.updated = cast(current_date() as timestamp),
+    __metadata.updated = cast(current_timestamp() as timestamp),
     {% endif %}
 {% else %}
     -- delete

--- a/framework/fabricks/cdc/templates/merge/scd2.sql.jinja
+++ b/framework/fabricks/cdc/templates/merge/scd2.sql.jinja
@@ -26,7 +26,7 @@
     __is_deleted = False,
 {% endif %}
 {% if has_metadata %}
-    __metadata.updated = cast(current_date() as timestamp),
+    __metadata.updated = cast(current_timestamp() as timestamp),
 {% endif %}
   when matched
   and __merge_condition == 'delete' then
@@ -38,7 +38,7 @@
     __is_deleted = True,
 {% endif %}
 {% if has_metadata %}
-    __metadata.updated = cast(current_date() as timestamp),
+    __metadata.updated = cast(current_timestamp() as timestamp),
 {% endif %}
   when not matched
   and __merge_condition == 'insert' then

--- a/framework/fabricks/core/jobs/silver.py
+++ b/framework/fabricks/core/jobs/silver.py
@@ -81,7 +81,7 @@ class Silver(BaseJob):
                         __metadata.file_size as file_size,            
                         __metadata.file_modification_time as file_modification_time,
                         __metadata.inserted as inserted,
-                    cast(current_date() as timestamp) as updated
+                    cast(current_timestamp() as timestamp) as updated
                     )
                     """
                 ),


### PR DESCRIPTION
Should fix: #45 